### PR TITLE
Fix: Preserve newlines in letter templates

### DIFF
--- a/backend/fastapi/app/services/templates.py
+++ b/backend/fastapi/app/services/templates.py
@@ -1,9 +1,15 @@
-
+import re
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+from markupsafe import Markup
 from pathlib import Path
 
 TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates"
 env = Environment(loader=FileSystemLoader(str(TEMPLATE_DIR)), autoescape=select_autoescape(['html','xml']))
+
+def nl2br(value: str) -> str:
+    return Markup(value.replace('\n', '<br>\n'))
+
+env.filters['nl2br'] = nl2br
 
 def render_letter(template_name: str, context: dict) -> str:
     return env.get_template(template_name).render(**context)

--- a/backend/fastapi/app/templates/ack.html
+++ b/backend/fastapi/app/templates/ack.html
@@ -2,7 +2,7 @@
 <p>Subject: Public Records Act Request – Acknowledgment</p>
 <p>Dear {{ request.requester.name }},</p>
 <p>We acknowledge receipt on {{ request.receivedDate }} of your request for:</p>
-<blockquote>{{ request.description }}</blockquote>
+<blockquote>{{ request.description | nl2br }}</blockquote>
 {% if request.range and (request.range.start or request.range.end) %}
 <p>for the period {{ request.range.start or '—' }} to {{ request.range.end or '—' }}.</p>
 {% endif %}


### PR DESCRIPTION
The Jinja2 templates were not correctly handling multiline strings in the request description, causing them to be rendered as a single line of text in the generated letters.

This commit introduces a custom `nl2br` filter that converts newline characters to `<br>` tags, ensuring that the formatting of the description is preserved in the final output. The filter's output is marked as safe to prevent auto-escaping by Jinja2.