### PR TITLE
Improve date parsing and validation in rules service

### DIFF
--- a/backend/fastapi/app/services/rules.py
+++ b/backend/fastapi/app/services/rules.py
@@ -1,12 +1,36 @@
 
 from datetime import date, timedelta
+from fastapi import HTTPException
+try:
+    from dateutil import parser as dateparser
+except ImportError:  # pragma: no cover - optional dependency
+    dateparser = None
 from ..models import CPRARequest, Timeline, TimelineItem
 
 def to_date(s: str) -> date:
+    """Convert a string to a ``date``.
+
+    Supports ISO format (``YYYY-MM-DD``), US-style ``MM/DD/YYYY`` and falls back
+    to ``dateutil.parser`` for more flexible parsing. Raises ``HTTPException`` if
+    the format is unrecognized.
+    """
+
     try:
         return date.fromisoformat(s)
-    except Exception:
-        parts = s.split('/'); return date(int(parts[2]), int(parts[0]), int(parts[1]))
+    except ValueError:
+        parts = s.split('/')
+        if len(parts) == 3:
+            try:
+                month, day, year = (int(p) for p in parts)
+                return date(year, month, day)
+            except ValueError:
+                pass
+        if dateparser is not None:
+            try:
+                return dateparser.parse(s).date()
+            except (ValueError, OverflowError):
+                pass
+        raise HTTPException(status_code=400, detail=f"Unrecognized date format: {s}")
 
 def roll_forward(d: date) -> date:
     if d.weekday() == 5: return d + timedelta(days=2) # Sat->Mon

--- a/backend/fastapi/requirements.txt
+++ b/backend/fastapi/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.115.0
 uvicorn[standard]==0.30.5
 jinja2==3.1.4
 pydantic==2.8.2
+python-dateutil==2.9.0.post0


### PR DESCRIPTION
## Summary
- Validate date strings and raise HTTPException for unknown formats
- Support flexible parsing with optional dateutil fallback
- Add python-dateutil dependency

## Testing
- `pip install -r backend/fastapi/requirements.txt` (fails: Could not find a version that satisfies the requirement python-dateutil==2.9.0.post0)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0c9af247483328790f0a395c74088