### PR TITLE
Improve frontend postJSON error handling

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,1 +1,15 @@
-export async function postJSON(url:string, body:any){ const r=await fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)}); if(!r.ok) throw new Error(await r.text()); return await r.json(); }
+export async function postJSON(url: string, body: any) {
+  try {
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!r.ok) {
+      throw new Error(await r.text());
+    }
+    return await r.json();
+  } catch (err) {
+    throw err instanceof Error ? err : new Error('Request failed');
+  }
+}

--- a/frontend/src/steps/LettersEditor.tsx
+++ b/frontend/src/steps/LettersEditor.tsx
@@ -1,1 +1,63 @@
-import React,{useEffect,useState} from 'react'; import { postJSON } from '../lib/api'; import type { CPRARequest, Timeline, LetterKind } from '../types'; export default function LettersEditor({req,tl,onAccept}:{req:CPRARequest,tl:Timeline,onAccept:()=>void}){ const [kind,setKind]=useState<LetterKind>('ack'); const [html,setHtml]=useState(''); useEffect(()=>{(async()=>{ const data=await postJSON(`/api/letters/${kind==='ack'?'ack':'extension'}`,{request:req,timeline:tl,agency:{signatureBlock:'City Clerk'}}); setHtml(data.html); })()},[kind,req,tl]); return <div className='space-y-3'><div className='flex gap-2'><button className={'btn '+(kind==='ack'?'bg-blue-600 text-white':'')} onClick={()=>setKind('ack')}>Acknowledgment</button><button className={'btn '+(kind==='extension'?'bg-blue-600 text-white':'')} onClick={()=>setKind('extension')}>Extension</button></div><textarea className='w-full border p-3 h-64' value={html} onChange={e=>setHtml(e.target.value)}></textarea><div className='flex justify-end'><button className='btn-primary' onClick={onAccept}>Accept Letter</button></div></div> }
+import React, { useEffect, useState } from 'react';
+import { postJSON } from '../lib/api';
+import type { CPRARequest, Timeline, LetterKind } from '../types';
+
+export default function LettersEditor({
+  req,
+  tl,
+  onAccept,
+}: {
+  req: CPRARequest;
+  tl: Timeline;
+  onAccept: () => void;
+}) {
+  const [kind, setKind] = useState<LetterKind>('ack');
+  const [html, setHtml] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await postJSON(
+          `/api/letters/${kind === 'ack' ? 'ack' : 'extension'}`,
+          { request: req, timeline: tl, agency: { signatureBlock: 'City Clerk' } }
+        );
+        setHtml(data.html);
+        setError(null);
+      } catch (e) {
+        console.error(e);
+        setError('Failed to load letter');
+      }
+    })();
+  }, [kind, req, tl]);
+
+  return (
+    <div className='space-y-3'>
+      <div className='flex gap-2'>
+        <button
+          className={'btn ' + (kind === 'ack' ? 'bg-blue-600 text-white' : '')}
+          onClick={() => setKind('ack')}
+        >
+          Acknowledgment
+        </button>
+        <button
+          className={'btn ' + (kind === 'extension' ? 'bg-blue-600 text-white' : '')}
+          onClick={() => setKind('extension')}
+        >
+          Extension
+        </button>
+      </div>
+      {error && <p className='text-red-600'>{error}</p>}
+      <textarea
+        className='w-full border p-3 h-64'
+        value={html}
+        onChange={e => setHtml(e.target.value)}
+      ></textarea>
+      <div className='flex justify-end'>
+        <button className='btn-primary' onClick={onAccept}>
+          Accept Letter
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/steps/NotesUpload.tsx
+++ b/frontend/src/steps/NotesUpload.tsx
@@ -1,1 +1,41 @@
-import React,{useState} from 'react'; import { postJSON } from '../lib/api'; import type { CPRARequest } from '../types'; export default function NotesUpload({onExtract}:{onExtract:(draft:CPRARequest)=>void}){ const [notes,setNotes]=useState('Public Records Act request by Jane Rivera <jrivera@example.com> on 2025-08-10. Records sought: emails and texts regarding agenda item 4.'); async function extract(){ const res=await postJSON('/api/extract/scope',{notes}); onExtract(res.request);} return <div className='space-y-3'><textarea className='w-full h-40 border p-3' value={notes} onChange={e=>setNotes(e.target.value)} /><div className='flex gap-2'><button className='btn-primary' onClick={extract}>Extract Draft Scope</button></div></div> }
+import React, { useState } from 'react';
+import { postJSON } from '../lib/api';
+import type { CPRARequest } from '../types';
+
+export default function NotesUpload({
+  onExtract,
+}: {
+  onExtract: (draft: CPRARequest) => void;
+}) {
+  const [notes, setNotes] = useState(
+    'Public Records Act request by Jane Rivera <jrivera@example.com> on 2025-08-10. Records sought: emails and texts regarding agenda item 4.'
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  async function extract() {
+    try {
+      const res = await postJSON('/api/extract/scope', { notes });
+      onExtract(res.request);
+      setError(null);
+    } catch (e) {
+      console.error(e);
+      setError('Failed to extract scope');
+    }
+  }
+
+  return (
+    <div className='space-y-3'>
+      <textarea
+        className='w-full h-40 border p-3'
+        value={notes}
+        onChange={e => setNotes(e.target.value)}
+      />
+      {error && <p className='text-red-600'>{error}</p>}
+      <div className='flex gap-2'>
+        <button className='btn-primary' onClick={extract}>
+          Extract Draft Scope
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/steps/TimelineView.tsx
+++ b/frontend/src/steps/TimelineView.tsx
@@ -1,1 +1,47 @@
-import React,{useEffect,useState} from 'react'; import Card from '../components/Card'; import { postJSON } from '../lib/api'; import type { CPRARequest, Timeline } from '../types'; export default function TimelineView({req,onApprove}:{req:CPRARequest,onApprove:(t:Timeline)=>void}){ const [tl,setTl]=useState<Timeline|null>(null); useEffect(()=>{(async()=>{ setTl(await postJSON('/api/timeline/calc',req)); })()},[req]); if(!tl) return <div>Calculating...</div>; const draftProd=tl.milestones.find(m=>m.label==='Draft production')?.due ?? ''; return <div className='space-y-4'><div className='grid grid-cols-3 gap-4'><Card title='Determination Due' value={tl.determinationDue}/>{tl.extensionDue && <Card title='Extension Due' value={tl.extensionDue}/>}<Card title='Draft Production' value={draftProd}/></div><div className='flex justify-end'><button className='btn-primary' onClick={()=>onApprove(tl)}>Approve Timeline</button></div></div> }
+import React, { useEffect, useState } from 'react';
+import Card from '../components/Card';
+import { postJSON } from '../lib/api';
+import type { CPRARequest, Timeline } from '../types';
+
+export default function TimelineView({
+  req,
+  onApprove,
+}: {
+  req: CPRARequest;
+  onApprove: (t: Timeline) => void;
+}) {
+  const [tl, setTl] = useState<Timeline | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setTl(await postJSON('/api/timeline/calc', req));
+        setError(null);
+      } catch (e) {
+        console.error(e);
+        setError('Failed to calculate timeline');
+      }
+    })();
+  }, [req]);
+
+  if (error) return <div className='text-red-600'>{error}</div>;
+  if (!tl) return <div>Calculating...</div>;
+
+  const draftProd = tl.milestones.find(m => m.label === 'Draft production')?.due ?? '';
+
+  return (
+    <div className='space-y-4'>
+      <div className='grid grid-cols-3 gap-4'>
+        <Card title='Determination Due' value={tl.determinationDue} />
+        {tl.extensionDue && <Card title='Extension Due' value={tl.extensionDue} />}
+        <Card title='Draft Production' value={draftProd} />
+      </div>
+      <div className='flex justify-end'>
+        <button className='btn-primary' onClick={() => onApprove(tl)}>
+          Approve Timeline
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add shared try/catch around fetch in `postJSON`
- handle request errors in NotesUpload, TimelineView, and LettersEditor
- surface failure messages to users

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `cd backend/express && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0cab8e9c4833288bcb9a5b952aab1