### PR TITLE
Implement CPRA handlers in Express backend

### DIFF
--- a/backend/express/package.json
+++ b/backend/express/package.json
@@ -6,7 +6,8 @@
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts"
   },
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "nunjucks": "^3.2.4"
   },
   "devDependencies": {
     "ts-node-dev": "^2.0.0",

--- a/backend/express/src/routes/cpra.ts
+++ b/backend/express/src/routes/cpra.ts
@@ -1,1 +1,53 @@
-import {Router} from 'express';const r=Router();r.post('/extract/scope',(req,res)=>res.json({ok:true}));r.post('/timeline/calc',(req,res)=>res.json({ok:true}));r.post('/letters/ack',(req,res)=>res.json({html:'<p>ack</p>'}));r.post('/letters/extension',(req,res)=>res.json({html:'<p>extension</p>'}));r.post('/tasks/sync',(req,res)=>res.json({createdEvents:[],icsFileBase64:'',emailsSent:0}));export default r;
+import { Router } from 'express';
+import { extractScope } from '../services/extractor.js';
+import { computeTimeline } from '../services/rules.js';
+import { renderLetter } from '../services/templates.js';
+import { createTaskSync } from '../services/tasksync.js';
+
+const r = Router();
+
+r.post('/extract/scope', (req, res) => {
+  const notes = req.body?.notes;
+  if (typeof notes !== 'string') {
+    return res.status(400).json({ detail: 'notes must be a string' });
+  }
+  return res.json(extractScope(notes));
+});
+
+r.post('/timeline/calc', (req, res) => {
+  const adjust = req.query.adjustForHolidays !== 'false';
+  try {
+    const timeline = computeTimeline(req.body, adjust);
+    return res.json(timeline);
+  } catch (err: any) {
+    return res.status(400).json({ detail: err.message });
+  }
+});
+
+r.post('/letters/ack', (req, res) => {
+  try {
+    const html = renderLetter('ack.html', req.body);
+    return res.json({ html });
+  } catch (err: any) {
+    return res.status(400).json({ detail: err.message });
+  }
+});
+
+r.post('/letters/extension', (req, res) => {
+  try {
+    const html = renderLetter('extension.html', req.body);
+    return res.json({ html });
+  } catch (err: any) {
+    return res.status(400).json({ detail: err.message });
+  }
+});
+
+r.post('/tasks/sync', (req, res) => {
+  try {
+    return res.json(createTaskSync(req.body));
+  } catch (err: any) {
+    return res.status(400).json({ detail: err.message });
+  }
+});
+
+export default r;

--- a/backend/express/src/services/extractor.ts
+++ b/backend/express/src/services/extractor.ts
@@ -1,0 +1,35 @@
+import type { CPRARequest, CPRARequestDraft, Requester } from './types.js';
+
+const EMAIL_RE = /[\w\.-]+@[\w\.-]+/;
+const DATE_RE = /(\b\d{4}-\d{2}-\d{2}\b|\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+\d{4}\b)/i;
+
+function firstEmail(text: string): string | null {
+  const m = text.match(EMAIL_RE);
+  return m ? m[0] : null;
+}
+
+function firstDate(text: string): string | null {
+  const m = text.match(DATE_RE);
+  return m ? m[0] : null;
+}
+
+export function extractScope(notes: string): CPRARequestDraft {
+  const email = firstEmail(notes) || 'requester@example.com';
+  let name = 'Unknown Requester';
+  const nameMatch = notes.match(/(?:from|by|request(?:or|ed) by)[:\s]+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)/i);
+  if (nameMatch) name = nameMatch[1];
+  const received = firstDate(notes) || '2025-01-01';
+  let desc = 'All emails related to agenda item';
+  const descMatch = notes.match(/(?:request|records sought)[:\s]+(.+)/i);
+  if (descMatch) desc = descMatch[1].trim();
+  const requester: Requester = { name, email };
+  const draft: CPRARequest = {
+    requester,
+    receivedDate: received,
+    description: desc,
+    range: {},
+    departments: [],
+    extension: { apply: false, reasons: [] }
+  };
+  return { request: draft, confidences: { requester: 0.6, receivedDate: 0.7, description: 0.6 } };
+}

--- a/backend/express/src/services/rules.ts
+++ b/backend/express/src/services/rules.ts
@@ -1,0 +1,56 @@
+import type { CPRARequest, Timeline, TimelineItem } from './types.js';
+
+function toDate(s: string): Date {
+  const iso = new Date(s);
+  if (!isNaN(iso.getTime())) return new Date(iso.getFullYear(), iso.getMonth(), iso.getDate());
+  const parts = s.split('/');
+  if (parts.length === 3) {
+    const [month, day, year] = parts.map(p => parseInt(p, 10));
+    const d = new Date(year, month - 1, day);
+    if (!isNaN(d.getTime())) return d;
+  }
+  const parsed = Date.parse(s);
+  if (!isNaN(parsed)) {
+    const d = new Date(parsed);
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  }
+  throw new Error(`Unrecognized date format: ${s}`);
+}
+
+function rollForward(d: Date): Date {
+  const day = d.getDay();
+  if (day === 6) return new Date(d.getTime() + 2 * 86400000);
+  if (day === 0) return new Date(d.getTime() + 1 * 86400000);
+  return d;
+}
+
+function fmt(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function computeTimeline(req: CPRARequest, adjustForHolidays = true): Timeline {
+  if (!req || !req.requester || !req.receivedDate || !req.description) {
+    throw new Error('Invalid CPRARequest');
+  }
+  const received = toDate(req.receivedDate);
+  let determination = new Date(received.getTime() + 10 * 86400000);
+  let extensionDue: Date | undefined;
+  if (req.extension && req.extension.apply) {
+    extensionDue = new Date(determination.getTime() + 14 * 86400000);
+  }
+  if (adjustForHolidays) {
+    determination = rollForward(determination);
+    if (extensionDue) extensionDue = rollForward(extensionDue);
+  }
+  const prodBase = extensionDue ? extensionDue : determination;
+  const milestones: TimelineItem[] = [
+    { label: 'Search kickoff', due: fmt(rollForward(new Date(received.getTime() + 1 * 86400000))) },
+    { label: 'Privilege review', due: fmt(rollForward(new Date(prodBase.getTime() - 3 * 86400000))) },
+    { label: 'Draft production', due: fmt(rollForward(new Date(prodBase.getTime() - 1 * 86400000))) },
+  ];
+  return {
+    determinationDue: fmt(determination),
+    extensionDue: extensionDue ? fmt(extensionDue) : undefined,
+    milestones,
+  };
+}

--- a/backend/express/src/services/tasksync.ts
+++ b/backend/express/src/services/tasksync.ts
@@ -1,0 +1,23 @@
+import { randomUUID } from 'crypto';
+
+function icsEvent(dtstart_date: string, summary: string, uid?: string, description = ''): string {
+  const id = uid || randomUUID();
+  const dtstamp = new Date().toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+  return `BEGIN:VEVENT\nUID:${id}\nDTSTAMP:${dtstamp}\nDTSTART;VALUE=DATE:${dtstart_date.replace(/-/g,'')}\nSUMMARY:${summary}\nDESCRIPTION:${description}\nEND:VEVENT`;
+}
+
+export function createTaskSync(payload: any) {
+  const tl = payload.timeline || {};
+  const events: string[] = [];
+  if (tl.determinationDue) events.push(icsEvent(tl.determinationDue, 'CPRA Determination Due'));
+  if (tl.extensionDue) events.push(icsEvent(tl.extensionDue, 'CPRA Extension Due'));
+  for (const m of tl.milestones || []) {
+    if (m.label === 'Draft production') events.push(icsEvent(m.due, 'CPRA Draft Production'));
+  }
+  const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//CPRA Planner//EN\n${events.join('\n')}\nEND:VCALENDAR\n`;
+  return {
+    createdEvents: [{ provider: 'ics', id: 'local', url: '' }],
+    icsFileBase64: Buffer.from(ics).toString('base64'),
+    emailsSent: 0,
+  };
+}

--- a/backend/express/src/services/templates.ts
+++ b/backend/express/src/services/templates.ts
@@ -1,0 +1,13 @@
+import nunjucks from 'nunjucks';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_DIR = path.resolve(__dirname, '../../../fastapi/app/templates');
+const env = nunjucks.configure(TEMPLATE_DIR, { autoescape: true });
+
+env.addFilter('nl2br', (str: string) => str.replace(/\n/g, '<br>\n'));
+
+export function renderLetter(template: string, context: Record<string, any>): string {
+  return env.render(template, context);
+}

--- a/backend/express/src/services/types.ts
+++ b/backend/express/src/services/types.ts
@@ -1,0 +1,46 @@
+export interface Requester {
+  name: string;
+  org?: string;
+  email?: string;
+}
+
+export interface DateRange {
+  start?: string;
+  end?: string;
+}
+
+export interface Extension {
+  apply: boolean;
+  reasons: string[];
+}
+
+export interface CPRARequest {
+  requester: Requester;
+  receivedDate: string;
+  description: string;
+  range?: DateRange;
+  departments: string[];
+  extension: Extension;
+}
+
+export interface TimelineItem {
+  label: string;
+  due: string;
+}
+
+export interface Timeline {
+  determinationDue: string;
+  extensionDue?: string;
+  milestones: TimelineItem[];
+}
+
+export interface CPRARequestDraft {
+  request: CPRARequest;
+  confidences: Record<string, number>;
+}
+
+export interface LetterArtifact {
+  html: string;
+  docxBase64?: string;
+  pdfBase64?: string;
+}

--- a/backend/express/src/templates/ack.html
+++ b/backend/express/src/templates/ack.html
@@ -1,1 +1,0 @@
-Ack template

--- a/backend/express/src/templates/extension.html
+++ b/backend/express/src/templates/extension.html
@@ -1,1 +1,0 @@
-Extension template


### PR DESCRIPTION
## Summary
- implement extract scope, timeline, letter, and task sync handlers in Express
- reuse FastAPI templates via Nunjucks to avoid duplication
- add nunjucks dependency

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npx tsc --noEmit` *(fails: Cannot find module 'nunjucks')*
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68b0cba116cc833298bc926a4453da59