### PR TITLE
Add backend service tests

### DIFF
--- a/backend/express/node_modules/nunjucks/index.js
+++ b/backend/express/node_modules/nunjucks/index.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+exports.configure = function(dir, _opts = {}) {
+  const env = {
+    filters: {},
+    addFilter(name, fn) { this.filters[name] = fn; },
+    render(template, context) {
+      let tpl = fs.readFileSync(path.join(dir, template), 'utf8');
+      tpl = tpl.replace(/\{%[^%]*%\}/g, '');
+      return tpl.replace(/{{\s*([^}]+)\s*}}/g, (_m, expr) => {
+        const parts = expr.split('|').map(p => p.trim());
+        const pathExpr = parts[0];
+        const filter = parts[1];
+        let val = pathExpr.split('.').reduce((acc, key) => (acc ? acc[key] : ''), context);
+        if (filter && env.filters[filter]) val = env.filters[filter](val);
+        return val ?? '';
+      });
+    },
+  };
+  return env;
+};

--- a/backend/express/tests/extractor.test.ts
+++ b/backend/express/tests/extractor.test.ts
@@ -1,0 +1,13 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractScope } from '../src/services/extractor.js';
+
+test('extractScope parses notes', () => {
+  const notes =
+    'Meeting notes from John Doe <john.doe@example.com> on 2025-01-05. Records sought: Budget documents.';
+  const draft = extractScope(notes);
+  assert.equal(draft.request.requester.email, 'john.doe@example.com');
+  assert.equal(draft.request.requester.name, 'John Doe');
+  assert.equal(draft.request.receivedDate, '2025-01-05');
+  assert.equal(draft.request.description, 'Budget documents.');
+});

--- a/backend/express/tests/rules.test.ts
+++ b/backend/express/tests/rules.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeTimeline } from '../src/services/rules.js';
+
+const baseReq = {
+  requester: { name: 'Jane', email: 'jane@example.com' },
+  receivedDate: '01/15/2025',
+  description: 'Records',
+  range: {},
+  departments: [],
+  extension: { apply: true, reasons: [] },
+};
+
+test('computeTimeline handles extension and roll forward', () => {
+  const tl = computeTimeline(baseReq);
+  assert.equal(tl.determinationDue, '2025-01-27');
+  assert.equal(tl.extensionDue, '2025-02-10');
+  const labels = tl.milestones.map(m => m.label);
+  assert(labels.includes('Draft production'));
+});
+
+test('computeTimeline parses natural language date', () => {
+  const tl = computeTimeline({ ...baseReq, receivedDate: 'Jan 15, 2025' });
+  assert.equal(tl.determinationDue, '2025-01-27');
+});
+
+test('computeTimeline rejects invalid date', () => {
+  assert.throws(() => computeTimeline({ ...baseReq, receivedDate: 'bad-date' }), /Unrecognized date format/);
+});

--- a/backend/express/tests/tasksync.test.ts
+++ b/backend/express/tests/tasksync.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createTaskSync } from '../src/services/tasksync.js';
+
+const payload = {
+  timeline: {
+    determinationDue: '2025-01-27',
+    extensionDue: '2025-02-10',
+    milestones: [{ label: 'Draft production', due: '2025-02-10' }],
+  },
+};
+
+test('createTaskSync builds ICS with events', () => {
+  const result = createTaskSync(payload);
+  const ics = Buffer.from(result.icsFileBase64, 'base64').toString();
+  assert.match(ics, /CPRA Determination Due/);
+  assert.match(ics, /CPRA Extension Due/);
+  assert.match(ics, /CPRA Draft Production/);
+});

--- a/backend/express/tests/templates.test.ts
+++ b/backend/express/tests/templates.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderLetter } from '../src/services/templates.js';
+
+test('renderLetter applies nl2br filter', () => {
+  const context = {
+    request: {
+      requester: { name: 'Jane', email: 'jane@example.com' },
+      receivedDate: '2025-01-01',
+      description: 'Line1\nLine2',
+      range: {},
+      departments: [],
+      extension: { apply: false, reasons: [] },
+    },
+    timeline: { determinationDue: '2025-01-10', milestones: [] },
+  };
+  const html = renderLetter('ack.html', context);
+  assert.ok(html.includes('Line1<br>\nLine2'));
+  assert.ok(html.includes('2025-01-10'));
+});

--- a/backend/fastapi/email_validator-2.0.0.dist-info/METADATA
+++ b/backend/fastapi/email_validator-2.0.0.dist-info/METADATA
@@ -1,0 +1,3 @@
+Metadata-Version: 2.1
+Name: email-validator
+Version: 2.0.0

--- a/backend/fastapi/email_validator.py
+++ b/backend/fastapi/email_validator.py
@@ -8,4 +8,6 @@ def validate_email(email: str, *_args, **_kwargs):
     class _Result:
         def __init__(self, email: str) -> None:
             self.email = email
+            self.normalized = email
+            self.local_part = email.split('@')[0]
     return _Result(email)

--- a/backend/fastapi/tests/test_extractor.py
+++ b/backend/fastapi/tests/test_extractor.py
@@ -1,0 +1,13 @@
+from app.services.extractor import extract_scope
+
+
+def test_extract_scope_parses_notes():
+    notes = (
+        "Meeting notes from John Doe <john.doe@example.com> on 2025-01-05. "
+        "Records sought: Budget documents."
+    )
+    draft = extract_scope(notes)
+    assert draft.request.requester.email == "john.doe@example.com"
+    assert draft.request.requester.name == "John Doe"
+    assert draft.request.receivedDate == "2025-01-05"
+    assert draft.request.description == "Budget documents."

--- a/backend/fastapi/tests/test_rules.py
+++ b/backend/fastapi/tests/test_rules.py
@@ -1,0 +1,36 @@
+from datetime import date
+import pytest
+from fastapi import HTTPException
+
+from app.models import CPRARequest, Requester, Extension
+from app.services import rules
+
+
+def test_to_date_parses_formats():
+    assert rules.to_date("2025-01-05") == date(2025, 1, 5)
+    assert rules.to_date("01/15/2025") == date(2025, 1, 15)
+    assert rules.to_date("Jan 2, 2025") == date(2025, 1, 2)
+    with pytest.raises(HTTPException):
+        rules.to_date("not-a-date")
+
+
+def test_roll_forward_weekends():
+    assert rules.roll_forward(date(2025, 1, 11)) == date(2025, 1, 13)
+    assert rules.roll_forward(date(2025, 1, 12)) == date(2025, 1, 13)
+    assert rules.roll_forward(date(2025, 1, 13)) == date(2025, 1, 13)
+
+
+def test_compute_timeline_with_extension():
+    req = CPRARequest(
+        requester=Requester(name="Jane", email="jane@example.com"),
+        receivedDate="2025-01-15",
+        description="Budget docs",
+        extension=Extension(apply=True),
+    )
+    tl = rules.compute_timeline(req)
+    assert tl.determinationDue == "2025-01-27"
+    assert tl.extensionDue == "2025-02-10"
+    labels = [m.label for m in tl.milestones]
+    assert "Draft production" in labels
+    draft_due = next(m.due for m in tl.milestones if m.label == "Draft production")
+    assert draft_due == "2025-02-10"

--- a/backend/fastapi/tests/test_tasksync.py
+++ b/backend/fastapi/tests/test_tasksync.py
@@ -1,0 +1,18 @@
+from base64 import b64decode
+
+from app.services.tasksync import create_task_sync
+
+
+def test_create_task_sync_generates_events():
+    payload = {
+        "timeline": {
+            "determinationDue": "2025-01-27",
+            "extensionDue": "2025-02-10",
+            "milestones": [{"label": "Draft production", "due": "2025-02-10"}],
+        }
+    }
+    result = create_task_sync(payload)
+    ics = b64decode(result["icsFileBase64"]).decode()
+    assert "CPRA Determination Due" in ics
+    assert "CPRA Extension Due" in ics
+    assert "CPRA Draft Production" in ics

--- a/backend/fastapi/tests/test_templates.py
+++ b/backend/fastapi/tests/test_templates.py
@@ -1,0 +1,27 @@
+from app.models import CPRARequest, Requester, Timeline, Extension
+from app.services.templates import render_letter
+
+
+def test_render_letter_ack_uses_nl2br():
+    req = CPRARequest(
+        requester=Requester(name="Jane", email="jane@example.com"),
+        receivedDate="2025-01-01",
+        description="Line1\nLine2",
+    )
+    tl = Timeline(determinationDue="2025-01-10")
+    html = render_letter("ack.html", {"request": req, "timeline": tl})
+    assert "Line1<br>\nLine2" in html
+    assert "2025-01-10" in html
+
+
+def test_render_letter_extension_includes_reason():
+    req = CPRARequest(
+        requester=Requester(name="Jane", email="jane@example.com"),
+        receivedDate="2025-01-01",
+        description="Test",
+        extension=Extension(apply=True, reasons=["need more time"]),
+    )
+    tl = Timeline(determinationDue="2025-01-10", extensionDue="2025-01-24")
+    html = render_letter("extension.html", {"request": req, "timeline": tl})
+    assert "need more time" in html
+    assert "2025-01-24" in html


### PR DESCRIPTION
## Summary
- Add FastAPI unit tests for scope extraction, rule helpers, timeline generation, template rendering, and task sync ICS creation
- Add Express unit tests mirroring FastAPI coverage and include lightweight nunjucks stub for rendering
- Provide stub email-validator metadata for offline testing

## Testing
- `PYTHONPATH=backend/fastapi pytest backend/fastapi/tests -q`
- `cd backend/express && TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm --test tests/*.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0d19b23f08332aa643cec661b0660