### PR TITLE
Document test suites and add testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,19 @@ npm run dev
 
 - Frontend at http://localhost:5173 proxies `/api/*` to FastAPI http://localhost:8000
 - Optional **Express** starter provided if you prefer Node later.
+
+## Running tests
+
+### Backend (FastAPI)
+```bash
+cd backend/fastapi
+pip install -r requirements.txt
+pytest
+```
+
+### Backend (Express)
+TypeScript tests use Node's built-in test runner with `ts-node`.
+```bash
+cd backend/express
+node --loader ts-node/esm --test tests/*.test.ts
+```

--- a/backend/express/tests/extractor.test.ts
+++ b/backend/express/tests/extractor.test.ts
@@ -1,7 +1,12 @@
+// Tests for scope extraction from meeting notes.
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { extractScope } from '../src/services/extractor.js';
 
+/**
+ * extractor.parseScope should convert notes into structured request data.
+ */
 test('extractScope parses notes', () => {
   const notes =
     'Meeting notes from John Doe <john.doe@example.com> on 2025-01-05. Records sought: Budget documents.';

--- a/backend/express/tests/rules.test.ts
+++ b/backend/express/tests/rules.test.ts
@@ -1,3 +1,5 @@
+// Tests for timeline computation rules.
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { computeTimeline } from '../src/services/rules.js';
@@ -11,6 +13,9 @@ const baseReq = {
   extension: { apply: true, reasons: [] },
 };
 
+/**
+ * computeTimeline should roll deadlines forward when extension applies.
+ */
 test('computeTimeline handles extension and roll forward', () => {
   const tl = computeTimeline(baseReq);
   assert.equal(tl.determinationDue, '2025-01-27');
@@ -19,11 +24,17 @@ test('computeTimeline handles extension and roll forward', () => {
   assert(labels.includes('Draft production'));
 });
 
+/**
+ * Natural language dates must be parsed correctly.
+ */
 test('computeTimeline parses natural language date', () => {
   const tl = computeTimeline({ ...baseReq, receivedDate: 'Jan 15, 2025' });
   assert.equal(tl.determinationDue, '2025-01-27');
 });
 
+/**
+ * Invalid dates should raise an error.
+ */
 test('computeTimeline rejects invalid date', () => {
   assert.throws(() => computeTimeline({ ...baseReq, receivedDate: 'bad-date' }), /Unrecognized date format/);
 });

--- a/backend/express/tests/tasksync.test.ts
+++ b/backend/express/tests/tasksync.test.ts
@@ -1,3 +1,5 @@
+// Tests for converting timelines into calendar events.
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createTaskSync } from '../src/services/tasksync.js';
@@ -10,6 +12,9 @@ const payload = {
   },
 };
 
+/**
+ * createTaskSync should include all relevant events in the ICS payload.
+ */
 test('createTaskSync builds ICS with events', () => {
   const result = createTaskSync(payload);
   const ics = Buffer.from(result.icsFileBase64, 'base64').toString();

--- a/backend/express/tests/templates.test.ts
+++ b/backend/express/tests/templates.test.ts
@@ -1,7 +1,12 @@
+// Tests for the template rendering service.
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { renderLetter } from '../src/services/templates.js';
 
+/**
+ * The acknowledgment template should convert newlines to <br> tags.
+ */
 test('renderLetter applies nl2br filter', () => {
   const context = {
     request: {

--- a/backend/fastapi/tests/test_extractor.py
+++ b/backend/fastapi/tests/test_extractor.py
@@ -1,7 +1,10 @@
+"""Tests for free-text scope extraction."""
+
 from app.services.extractor import extract_scope
 
 
 def test_extract_scope_parses_notes():
+    """extract_scope interprets meeting notes into structured data."""
     notes = (
         "Meeting notes from John Doe <john.doe@example.com> on 2025-01-05. "
         "Records sought: Budget documents."

--- a/backend/fastapi/tests/test_rules.py
+++ b/backend/fastapi/tests/test_rules.py
@@ -1,3 +1,5 @@
+"""Tests for rules computing CPRA timelines and dates."""
+
 from datetime import date
 import pytest
 from fastapi import HTTPException
@@ -7,6 +9,7 @@ from app.services import rules
 
 
 def test_to_date_parses_formats():
+    """to_date accepts multiple input formats and rejects invalid ones."""
     assert rules.to_date("2025-01-05") == date(2025, 1, 5)
     assert rules.to_date("01/15/2025") == date(2025, 1, 15)
     assert rules.to_date("Jan 2, 2025") == date(2025, 1, 2)
@@ -15,12 +18,14 @@ def test_to_date_parses_formats():
 
 
 def test_roll_forward_weekends():
+    """roll_forward moves weekend dates to the following Monday."""
     assert rules.roll_forward(date(2025, 1, 11)) == date(2025, 1, 13)
     assert rules.roll_forward(date(2025, 1, 12)) == date(2025, 1, 13)
     assert rules.roll_forward(date(2025, 1, 13)) == date(2025, 1, 13)
 
 
 def test_compute_timeline_with_extension():
+    """compute_timeline returns correct deadlines when extensions apply."""
     req = CPRARequest(
         requester=Requester(name="Jane", email="jane@example.com"),
         receivedDate="2025-01-15",

--- a/backend/fastapi/tests/test_tasksync.py
+++ b/backend/fastapi/tests/test_tasksync.py
@@ -1,9 +1,12 @@
+"""Tests for the task synchronization service."""
+
 from base64 import b64decode
 
 from app.services.tasksync import create_task_sync
 
 
 def test_create_task_sync_generates_events():
+    """create_task_sync builds an ICS file with expected event names."""
     payload = {
         "timeline": {
             "determinationDue": "2025-01-27",

--- a/backend/fastapi/tests/test_templates.py
+++ b/backend/fastapi/tests/test_templates.py
@@ -1,8 +1,11 @@
+"""Tests for template rendering utilities."""
+
 from app.models import CPRARequest, Requester, Timeline, Extension
 from app.services.templates import render_letter
 
 
 def test_render_letter_ack_uses_nl2br():
+    """Ack template converts newlines to `<br>` tags."""
     req = CPRARequest(
         requester=Requester(name="Jane", email="jane@example.com"),
         receivedDate="2025-01-01",
@@ -15,6 +18,7 @@ def test_render_letter_ack_uses_nl2br():
 
 
 def test_render_letter_extension_includes_reason():
+    """Extension letter includes provided reason and due date."""
     req = CPRARequest(
         requester=Requester(name="Jane", email="jane@example.com"),
         receivedDate="2025-01-01",


### PR DESCRIPTION
## Summary
- add module and function docstrings across Python test files
- annotate TypeScript tests with descriptive comments
- document how to run FastAPI and Express test suites in the README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*
- `node --loader ts-node/esm --test tests/*.test.ts` *(fails: test failed for templates.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d410719c83329346b14ccfe2a662