### PR TITLE
docs: add express quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 Thin prototype to turn meeting notes into a CPRA scope sheet, compute deadlines,
 draft acknowledgment/extension letters, and sync tasks (calendar/email).
 
-## Quick start (FastAPI + Frontend)
+## Quick start
 
-### 1) Backend (FastAPI)
+### Backend (FastAPI)
 ```bash
 cd backend/fastapi
 python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
@@ -14,15 +14,22 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
-### 2) Frontend
+### Backend (Express, optional)
+```bash
+cd backend/express
+npm install
+npm run dev
+```
+
+### Frontend
 ```bash
 cd frontend
 npm install
 npm run dev
 ```
 
-- Frontend at http://localhost:5173 proxies `/api/*` to FastAPI http://localhost:8000
-- Optional **Express** starter provided if you prefer Node later.
+- Frontend at http://localhost:5173 proxies `/api/*` to FastAPI at http://localhost:8000.
+- Express backend listens on http://localhost:8080 (update `frontend/vite.config.ts` if you use it).
 
 ## Running tests
 
@@ -30,7 +37,7 @@ npm run dev
 ```bash
 cd backend/fastapi
 pip install -r requirements.txt
-pytest
+PYTHONPATH=. pytest
 ```
 
 ### Backend (Express)


### PR DESCRIPTION
## Summary
- document optional Express backend in quick start
- clarify frontend proxy and Express port
- note PYTHONPATH requirement for backend tests

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `PYTHONPATH=. pytest`
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b0d581d22c83329d83b8ca1b9f714f