### PR TITLE
Relax FastAPI dependency pin

### DIFF
--- a/backend/fastapi/requirements.txt
+++ b/backend/fastapi/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.115.0
+fastapi>=0.110,<0.116
 uvicorn[standard]==0.30.5
 jinja2==3.1.4
 pydantic==2.8.2


### PR DESCRIPTION
## Summary
- relax FastAPI dependency to allow any release between 0.110 and <0.116

## Testing
- `pip install -r backend/fastapi/requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68b0d7bd10d88332a12526cfbf941ad5