### PR TITLE
Fix pytest module path for FastAPI app

### DIFF
--- a/backend/fastapi/app/__init__.py
+++ b/backend/fastapi/app/__init__.py
@@ -1,0 +1,1 @@
+"""Initialize the FastAPI application package."""

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Ensure backend/fastapi is on the Python path for tests
+sys.path.append(os.path.join(os.path.dirname(__file__), 'backend', 'fastapi'))


### PR DESCRIPTION
## Summary
- add package initializer for backend FastAPI app
- ensure tests discover app module by adding root conftest

## Testing
- `pip install -r backend/fastapi/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0d8fe4e288332a1968f33e7bad33b