### PR TITLE
docs: add API model docstrings

### DIFF
--- a/backend/fastapi/app/main.py
+++ b/backend/fastapi/app/main.py
@@ -1,4 +1,6 @@
 
+"""Application factory for the CPRA planner FastAPI service."""
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .routers.cpra import router as cpra_router

--- a/backend/fastapi/app/models.py
+++ b/backend/fastapi/app/models.py
@@ -1,21 +1,31 @@
 
+"""Pydantic models describing API payloads and artifacts for the CPRA planner."""
+
 from pydantic import BaseModel, EmailStr, Field
 from typing import List, Optional, Dict
 
 class Requester(BaseModel):
+    """Information about the person making a CPRA request."""
+
     name: str
     org: Optional[str] = None
     email: Optional[EmailStr] = None
 
 class DateRange(BaseModel):
+    """Optional start and end dates for the records being requested."""
+
     start: Optional[str] = None
     end: Optional[str] = None
 
 class Extension(BaseModel):
+    """Whether a deadline extension is applied and the reasons for it."""
+
     apply: bool = False
     reasons: List[str] = Field(default_factory=list)
 
 class CPRARequest(BaseModel):
+    """A complete CPRA request as provided by a requester."""
+
     requester: Requester
     receivedDate: str
     description: str
@@ -24,19 +34,27 @@ class CPRARequest(BaseModel):
     extension: Extension = Field(default_factory=Extension)
 
 class TimelineItem(BaseModel):
+    """Single milestone in the processing timeline."""
+
     label: str
     due: str
 
 class Timeline(BaseModel):
+    """Collection of statutory deadlines and milestone dates."""
+
     determinationDue: str
     extensionDue: Optional[str] = None
     milestones: List[TimelineItem] = Field(default_factory=list)
 
 class CPRARequestDraft(BaseModel):
+    """Draft CPRA request with confidence scores for extracted fields."""
+
     request: CPRARequest
     confidences: Dict[str, float] = Field(default_factory=dict)
 
 class LetterArtifact(BaseModel):
+    """Rendered letter output in various formats."""
+
     html: str
     docxBase64: str = ""
     pdfBase64: str = ""


### PR DESCRIPTION
## Summary
- document FastAPI application entry point
- add comprehensive docstrings for CPRA-related Pydantic models

## Testing
- `PYTHONPATH=. pytest`
- `node --loader ts-node/esm --test tests/*.test.ts` *(fails: renderLetter applies nl2br filter)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f427d304833282e58ca5fa850312