### PR TITLE
Add stepper navigation, context panel, and demo utilities

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,32 +1,151 @@
-
-import React, { useState } from 'react'
-import NotesUpload from './steps/NotesUpload'
-import ScopeForm from './steps/ScopeForm'
-import TimelineView from './steps/TimelineView'
-import LettersEditor from './steps/LettersEditor'
-import TasksAndChecklist from './steps/TasksAndChecklist'
-import type { CPRARequest, Timeline } from './types'
+import React, { useEffect, useRef, useState } from 'react';
+import Stepper from './components/Stepper';
+import ContextPanel, { StepContext } from './components/ContextPanel';
+import NotesUpload from './steps/NotesUpload';
+import ScopeForm from './steps/ScopeForm';
+import TimelineView from './steps/TimelineView';
+import LettersEditor from './steps/LettersEditor';
+import TasksAndChecklist from './steps/TasksAndChecklist';
+import type { CPRARequest, Timeline } from './types';
 
 /** Root application component orchestrating the workflow steps. */
-export default function App(){
-  const [step,setStep]=useState(0)
-  const [req,setReq]=useState<CPRARequest|null>(null)
-  const [tl,setTl]=useState<Timeline|null>(null)
-  const recipients = ['clerk@example.com']
+export default function App() {
+  const steps = ['Notes', 'Scope', 'Timeline', 'Letters', 'Tasks'];
+  const contexts: StepContext[] = [
+    {
+      does: 'Upload attorney notes to start the demo.',
+      ai: 'Parses notes to draft a request scope.',
+      lawyer: 'Checks the extracted details.',
+    },
+    {
+      does: 'Review and edit the extracted scope.',
+      ai: 'Drafts request details from the notes.',
+      lawyer: 'Edits fields or accepts as-is.',
+    },
+    {
+      does: 'Confirm statutory timeline.',
+      ai: 'Calculates deadlines based on the request.',
+      lawyer: 'Approves the schedule.',
+    },
+    {
+      does: 'Review draft acknowledgment or extension letters.',
+      ai: 'Generates letter templates.',
+      lawyer: 'Edits language or accepts the draft.',
+    },
+    {
+      does: 'Track redaction tasks and create calendar holds.',
+      ai: 'Suggests checklist items and events.',
+      lawyer: 'Completes tasks and downloads calendar file.',
+    },
+  ];
+
+  const SAMPLE_NOTES =
+    'Public Records Act request by Jane Rivera <jrivera@example.com> on 2025-08-10. Records sought: emails and texts regarding agenda item 4.';
+
+  const [step, setStep] = useState(0);
+  const [notes, setNotes] = useState('');
+  const [req, setReq] = useState<CPRARequest | null>(null);
+  const [tl, setTl] = useState<Timeline | null>(null);
+  const nextRef = useRef<() => Promise<any> | any>(() => {});
+  const [canNext, setCanNext] = useState(true);
+  const startRef = useRef(Date.now());
+
+  function registerNext(fn: () => Promise<any> | any, ready = true) {
+    nextRef.current = fn;
+    setCanNext(ready);
+  }
+
+  useEffect(() => {
+    startRef.current = Date.now();
+  }, [step]);
+
+  async function handleNext() {
+    if (!canNext) return;
+    try {
+      const result = await nextRef.current();
+      let action: 'accept' | 'edit' = 'accept';
+      switch (step) {
+        case 0:
+          setReq(result);
+          action = notes === SAMPLE_NOTES ? 'accept' : 'edit';
+          break;
+        case 1:
+          action = JSON.stringify(result) === JSON.stringify(req) ? 'accept' : 'edit';
+          setReq(result);
+          break;
+        case 2:
+          setTl(result);
+          action = 'accept';
+          break;
+        case 3:
+          action = result.edited ? 'edit' : 'accept';
+          break;
+      }
+      const ms = Date.now() - startRef.current;
+      console.log(`Step ${steps[step]}: ${action} in ${ms}ms`);
+      setStep(s => s + 1);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  function handleBack() {
+    if (step === 0) return;
+    setStep(s => s - 1);
+  }
+
+  function resetDemo() {
+    setNotes('');
+    setReq(null);
+    setTl(null);
+    setStep(0);
+  }
+
+  function loadSample() {
+    setNotes(SAMPLE_NOTES);
+  }
 
   return (
-    <div className='max-w-5xl mx-auto p-6 space-y-6'>
-      <h1 className='text-2xl font-bold'>CPRA Response Planner (MVP)</h1>
-      <div className='flex gap-2 text-sm'>
-        {['Notes','Scope','Timeline','Letters','Tasks'].map((s,i)=>(
-          <div key={i} className={'px-2 py-1 rounded ' + (i===step?'bg-blue-600 text-white':'bg-gray-100')}>{i+1}. {s}</div>
-        ))}
+    <div className='max-w-5xl mx-auto p-6'>
+      <header className='flex justify-between items-center mb-4'>
+        <h1 className='text-2xl font-bold'>CPRA Response Planner (MVP)</h1>
+        <div className='space-x-2 text-sm'>
+          <button className='btn' onClick={resetDemo}>Reset demo</button>
+          <button className='btn' onClick={loadSample}>Load sample notes</button>
+        </div>
+      </header>
+      <div className='flex gap-6'>
+        <div className='flex-1'>
+          {step === 0 && (
+            <NotesUpload notes={notes} setNotes={setNotes} registerNext={registerNext} />
+          )}
+          {step === 1 && req && <ScopeForm draft={req} registerNext={registerNext} />}
+          {step === 2 && req && <TimelineView req={req} registerNext={registerNext} />}
+          {step === 3 && req && tl && (
+            <LettersEditor req={req} tl={tl} registerNext={registerNext} />
+          )}
+          {step === 4 && tl && (
+            <TasksAndChecklist
+              matterId={'demo-1'}
+              tl={tl}
+              recipients={['clerk@example.com']}
+            />
+          )}
+        </div>
+        <aside className='w-64'>
+          <ContextPanel context={contexts[step]} />
+        </aside>
       </div>
-      {step===0 && <NotesUpload onExtract={(d)=>{setReq(d); setStep(1)}}/>}
-      {step===1 && req && <ScopeForm draft={req} onApprove={(r)=>{ setReq(r); setStep(2) }}/>} 
-      {step===2 && req && <TimelineView req={req} onApprove={(t)=>{ setTl(t); setStep(3) }}/>} 
-      {step===3 && req && tl && <LettersEditor req={req} tl={tl} onAccept={()=>setStep(4)} />}
-      {step===4 && tl && <TasksAndChecklist matterId={'demo-1'} tl={tl} recipients={recipients} />}
+      <footer className='sticky bottom-0 bg-white border-t mt-4 py-3'>
+        <Stepper
+          current={step}
+          labels={steps}
+          onBack={handleBack}
+          onNext={handleNext}
+          disableBack={step === 0}
+          disableNext={!canNext || step === steps.length - 1}
+        />
+      </footer>
     </div>
-  )
+  );
 }

--- a/frontend/src/components/ContextPanel.tsx
+++ b/frontend/src/components/ContextPanel.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export type StepContext = {
+  does: string;
+  ai: string;
+  lawyer: string;
+};
+
+/** Side panel explaining the current step. */
+export default function ContextPanel({ context }: { context: StepContext }) {
+  return (
+    <div className='space-y-4 text-sm'>
+      <div>
+        <h2 className='font-semibold'>What this step does</h2>
+        <p>{context.does}</p>
+      </div>
+      <div>
+        <h2 className='font-semibold'>What the AI drafts</h2>
+        <p>{context.ai}</p>
+      </div>
+      <div>
+        <h2 className='font-semibold'>What the lawyer decides</h2>
+        <p>{context.lawyer}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Stepper.tsx
+++ b/frontend/src/components/Stepper.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+/** Display step progress with back/next navigation in a sticky footer. */
+export default function Stepper({
+  current,
+  labels,
+  onBack,
+  onNext,
+  disableBack,
+  disableNext,
+}: {
+  current: number;
+  labels: string[];
+  onBack: () => void;
+  onNext: () => void;
+  disableBack?: boolean;
+  disableNext?: boolean;
+}) {
+  return (
+    <div className='flex items-center justify-between'>
+      <div className='text-sm'>{`${current + 1}/${labels.length} ${labels[current]}`}</div>
+      <div className='space-x-2'>
+        <button className='btn' onClick={onBack} disabled={disableBack}>
+          Back
+        </button>
+        <button className='btn-primary' onClick={onNext} disabled={disableNext}>
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/steps/LettersEditor.tsx
+++ b/frontend/src/steps/LettersEditor.tsx
@@ -6,14 +6,15 @@ import type { CPRARequest, Timeline, LetterKind } from '../types';
 export default function LettersEditor({
   req,
   tl,
-  onAccept,
+  registerNext,
 }: {
   req: CPRARequest;
   tl: Timeline;
-  onAccept: () => void;
+  registerNext: (fn: () => { edited: boolean }, ready?: boolean) => void;
 }) {
   const [kind, setKind] = useState<LetterKind>('ack');
   const [html, setHtml] = useState('');
+  const [initialHtml, setInitialHtml] = useState('');
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -24,6 +25,7 @@ export default function LettersEditor({
           { request: req, timeline: tl, agency: { signatureBlock: 'City Clerk' } }
         );
         setHtml(data.html);
+        setInitialHtml(data.html);
         setError(null);
       } catch (e) {
         console.error(e);
@@ -31,6 +33,10 @@ export default function LettersEditor({
       }
     })();
   }, [kind, req, tl]);
+
+  useEffect(() => {
+    registerNext(() => ({ edited: html !== initialHtml }), html !== '');
+  }, [html, initialHtml, registerNext]);
 
   return (
     <div className='space-y-3'>
@@ -54,11 +60,7 @@ export default function LettersEditor({
         value={html}
         onChange={e => setHtml(e.target.value)}
       ></textarea>
-      <div className='flex justify-end'>
-        <button className='btn-primary' onClick={onAccept}>
-          Accept Letter
-        </button>
-      </div>
+      {/* Primary action moved to Stepper */}
     </div>
   );
 }

--- a/frontend/src/steps/NotesUpload.tsx
+++ b/frontend/src/steps/NotesUpload.tsx
@@ -1,29 +1,35 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { postJSON } from '../lib/api';
 import type { CPRARequest } from '../types';
 
 /** Step for uploading notes and extracting a draft scope. */
 export default function NotesUpload({
-  onExtract,
+  notes,
+  setNotes,
+  registerNext,
 }: {
-  onExtract: (draft: CPRARequest) => void;
+  notes: string;
+  setNotes: (s: string) => void;
+  registerNext: (fn: () => Promise<CPRARequest>, ready?: boolean) => void;
 }) {
-  const [notes, setNotes] = useState(
-    'Public Records Act request by Jane Rivera <jrivera@example.com> on 2025-08-10. Records sought: emails and texts regarding agenda item 4.'
-  );
   const [error, setError] = useState<string | null>(null);
 
   /** Call the backend to extract a CPRA scope from notes. */
   async function extract() {
     try {
       const res = await postJSON('/api/extract/scope', { notes });
-      onExtract(res.request);
       setError(null);
+      return res.request as CPRARequest;
     } catch (e) {
       console.error(e);
       setError('Failed to extract scope');
+      throw e;
     }
   }
+
+  useEffect(() => {
+    registerNext(extract, notes.trim().length > 0);
+  }, [notes, registerNext]);
 
   return (
     <div className='space-y-3'>
@@ -33,11 +39,6 @@ export default function NotesUpload({
         onChange={e => setNotes(e.target.value)}
       />
       {error && <p className='text-red-600'>{error}</p>}
-      <div className='flex gap-2'>
-        <button className='btn-primary' onClick={extract}>
-          Extract Draft Scope
-        </button>
-      </div>
     </div>
   );
 }

--- a/frontend/src/steps/ScopeForm.tsx
+++ b/frontend/src/steps/ScopeForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { CPRARequest } from '../types';
 
 /**
@@ -6,10 +6,10 @@ import type { CPRARequest } from '../types';
  */
 export default function ScopeForm({
   draft,
-  onApprove,
+  registerNext,
 }: {
   draft: CPRARequest;
-  onApprove: (r: CPRARequest) => void;
+  registerNext: (fn: () => CPRARequest) => void;
 }) {
   const [f, setF] = useState<CPRARequest>(draft);
 
@@ -26,6 +26,10 @@ export default function ScopeForm({
       return c;
     });
   }
+
+  useEffect(() => {
+    registerNext(() => f);
+  }, [f, registerNext]);
 
   return (
     <div className='grid grid-cols-2 gap-4'>
@@ -102,11 +106,7 @@ export default function ScopeForm({
           onChange={e => up('extension.apply', e.target.checked)}
         />
       </div>
-      <div className='col-span-2 flex justify-end'>
-        <button className='btn-primary' onClick={() => onApprove(f)}>
-          Approve Scope
-        </button>
-      </div>
+      {/* Primary action moved to Stepper */}
     </div>
   );
 }

--- a/frontend/src/steps/TimelineView.tsx
+++ b/frontend/src/steps/TimelineView.tsx
@@ -6,10 +6,10 @@ import type { CPRARequest, Timeline } from '../types';
 /** Display the computed timeline for approval. */
 export default function TimelineView({
   req,
-  onApprove,
+  registerNext,
 }: {
   req: CPRARequest;
-  onApprove: (t: Timeline) => void;
+  registerNext: (fn: () => Timeline, ready?: boolean) => void;
 }) {
   const [tl, setTl] = useState<Timeline | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -26,6 +26,10 @@ export default function TimelineView({
     })();
   }, [req]);
 
+  useEffect(() => {
+    registerNext(() => tl!, !!tl);
+  }, [tl, registerNext]);
+
   if (error) return <div className='text-red-600'>{error}</div>;
   if (!tl) return <div>Calculating...</div>;
 
@@ -38,11 +42,7 @@ export default function TimelineView({
         {tl.extensionDue && <Card title='Extension Due' value={tl.extensionDue} />}
         <Card title='Draft Production' value={draftProd} />
       </div>
-      <div className='flex justify-end'>
-        <button className='btn-primary' onClick={() => onApprove(tl)}>
-          Approve Timeline
-        </button>
-      </div>
+      {/* Primary action moved to Stepper */}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Introduce reusable Stepper component with progress and Back/Next navigation
- Add ContextPanel to explain each workflow step
- Refactor App to use Stepper and ContextPanel, log time per step, and provide reset/sample utilities

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b207120a588332aa6ab59e3be2d8b7