### PR TITLE
feat: preview notes extraction client-side

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import TimelineView from './steps/TimelineView';
 import LettersEditor from './steps/LettersEditor';
 import TasksAndChecklist from './steps/TasksAndChecklist';
 import type { CPRARequest, Timeline } from './types';
+import { SAMPLE_NOTES } from './sampleNotes';
 
 /** Root application component orchestrating the workflow steps. */
 export default function App() {
@@ -39,9 +40,6 @@ export default function App() {
     },
   ];
 
-  const SAMPLE_NOTES =
-    'Public Records Act request by Jane Rivera <jrivera@example.com> on 2025-08-10. Records sought: emails and texts regarding agenda item 4.';
-
   const [step, setStep] = useState(0);
   const [notes, setNotes] = useState('');
   const [req, setReq] = useState<CPRARequest | null>(null);
@@ -64,10 +62,12 @@ export default function App() {
     try {
       const result = await nextRef.current();
       let action: 'accept' | 'edit' = 'accept';
+      let editedSample = false;
       switch (step) {
         case 0:
           setReq(result);
-          action = notes === SAMPLE_NOTES ? 'accept' : 'edit';
+          editedSample = notes !== SAMPLE_NOTES;
+          action = editedSample ? 'edit' : 'accept';
           break;
         case 1:
           action = JSON.stringify(result) === JSON.stringify(req) ? 'accept' : 'edit';
@@ -82,7 +82,11 @@ export default function App() {
           break;
       }
       const ms = Date.now() - startRef.current;
-      console.log(`Step ${steps[step]}: ${action} in ${ms}ms`);
+      if (step === 0) {
+        console.log(`Notes step: ${ms}ms, editedSample=${editedSample}`);
+      } else {
+        console.log(`Step ${steps[step]}: ${action} in ${ms}ms`);
+      }
       setStep(s => s + 1);
     } catch (e) {
       console.error(e);

--- a/frontend/src/sampleNotes.ts
+++ b/frontend/src/sampleNotes.ts
@@ -1,0 +1,1 @@
+export const SAMPLE_NOTES = 'Public Records Act request by Jane Rivera <jrivera@example.com> on 2025-08-10. Records sought: emails and texts regarding agenda item 4.';

--- a/frontend/src/steps/NotesUpload.tsx
+++ b/frontend/src/steps/NotesUpload.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { postJSON } from '../lib/api';
 import type { CPRARequest } from '../types';
+import { SAMPLE_NOTES } from '../sampleNotes';
 
 /** Step for uploading notes and extracting a draft scope. */
 export default function NotesUpload({
@@ -14,12 +14,58 @@ export default function NotesUpload({
 }) {
   const [error, setError] = useState<string | null>(null);
 
-  /** Call the backend to extract a CPRA scope from notes. */
+  type Preview = {
+    requester: string | null;
+    received: string | null;
+    description: string | null;
+    conf: { requester: number; received: number; description: number };
+  };
+
+  const [preview, setPreview] = useState<Preview | null>(null);
+
+  /**
+   * Very small client-side parser to simulate extraction. Looks for patterns
+   * like "request by NAME <email> on YYYY-MM-DD" and "Records sought: ...".
+   */
+  function simulateExtraction(text: string): Preview {
+    const nameMatch = text.match(/request by ([^<\n]+)</i);
+    const dateMatch = text.match(/on (\d{4}-\d{2}-\d{2})/);
+    const descMatch = text.match(/records sought:([^\.]+)/i);
+    return {
+      requester: nameMatch ? nameMatch[1].trim() : null,
+      received: dateMatch ? dateMatch[1] : null,
+      description: descMatch ? descMatch[1].trim() : null,
+      conf: {
+        requester: nameMatch ? 0.9 : 0.2,
+        received: dateMatch ? 0.9 : 0.2,
+        description: descMatch ? 0.9 : 0.2,
+      },
+    };
+  }
+
+  /** Load preview whenever notes change. */
+  useEffect(() => {
+    if (notes.trim().length > 0) {
+      setPreview(simulateExtraction(notes));
+    } else {
+      setPreview(null);
+    }
+    registerNext(extract, notes.trim().length > 0);
+  }, [notes, registerNext]);
+
+  /** Simulated extraction returning a CPRARequest object. */
   async function extract() {
     try {
-      const res = await postJSON('/api/extract/scope', { notes });
+      const p = simulateExtraction(notes);
       setError(null);
-      return res.request as CPRARequest;
+      return {
+        requester: { name: p.requester ?? '' },
+        receivedDate: p.received ?? '',
+        description: p.description ?? '',
+        range: {},
+        departments: [],
+        extension: { apply: false, reasons: [] },
+      } as CPRARequest;
     } catch (e) {
       console.error(e);
       setError('Failed to extract scope');
@@ -27,9 +73,29 @@ export default function NotesUpload({
     }
   }
 
-  useEffect(() => {
-    registerNext(extract, notes.trim().length > 0);
-  }, [notes, registerNext]);
+  function loadSample() {
+    setNotes(SAMPLE_NOTES);
+  }
+
+  function ConfidenceChip({ score }: { score: number }) {
+    let label = 'Low';
+    let color = 'bg-red-200';
+    if (score > 0.8) {
+      label = 'High';
+      color = 'bg-green-200';
+    } else if (score > 0.5) {
+      label = 'Med';
+      color = 'bg-yellow-200';
+    }
+    return (
+      <span
+        className={`ml-2 px-2 py-0.5 rounded text-xs ${color}`}
+        title={`Confidence ${(score * 100).toFixed(0)}%`}
+      >
+        {label}
+      </span>
+    );
+  }
 
   return (
     <div className='space-y-3'>
@@ -37,7 +103,35 @@ export default function NotesUpload({
         className='w-full h-40 border p-3'
         value={notes}
         onChange={e => setNotes(e.target.value)}
+        placeholder='Paste attorney notes here...'
       />
+      {notes.trim().length === 0 && (
+        <div className='text-center text-sm text-gray-500 space-y-2'>
+          <p>No notes loaded yet.</p>
+          <button className='btn' type='button' onClick={loadSample}>
+            Load sample notes
+          </button>
+        </div>
+      )}
+      {preview && (
+        <div className='space-y-1 text-sm'>
+          <p>
+            <span className='font-medium'>Requester:</span>{' '}
+            {preview.requester || <span className='text-gray-400'>N/A</span>}
+            <ConfidenceChip score={preview.conf.requester} />
+          </p>
+          <p>
+            <span className='font-medium'>Received:</span>{' '}
+            {preview.received || <span className='text-gray-400'>N/A</span>}
+            <ConfidenceChip score={preview.conf.received} />
+          </p>
+          <p>
+            <span className='font-medium'>Description:</span>{' '}
+            {preview.description || <span className='text-gray-400'>N/A</span>}
+            <ConfidenceChip score={preview.conf.description} />
+          </p>
+        </div>
+      )}
       {error && <p className='text-red-600'>{error}</p>}
     </div>
   );


### PR DESCRIPTION
## Summary
- simulate notes extraction in browser and show requester, date, and description with confidence chips
- add empty state hint and sample note loader
- log time spent and if sample notes were edited

## Testing
- `npm run build -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b2090fc6e88332aee826a95100d3fe