### PR TITLE
Compute timeline client-side with interactive date math

### DIFF
--- a/frontend/src/lib/timeline.ts
+++ b/frontend/src/lib/timeline.ts
@@ -1,0 +1,81 @@
+import type { CPRARequest, Timeline } from '../types';
+
+function toDate(s: string): Date {
+  const iso = new Date(s);
+  if (!isNaN(iso.getTime())) {
+    return new Date(iso.getFullYear(), iso.getMonth(), iso.getDate());
+  }
+  const parts = s.split('/');
+  if (parts.length === 3) {
+    const [month, day, year] = parts.map(p => parseInt(p, 10));
+    const d = new Date(year, month - 1, day);
+    if (!isNaN(d.getTime())) return d;
+  }
+  const parsed = Date.parse(s);
+  if (!isNaN(parsed)) {
+    const d = new Date(parsed);
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  }
+  throw new Error('Unrecognized date format');
+}
+
+function addDays(d: Date, days: number) {
+  return new Date(d.getTime() + days * 86400000);
+}
+
+function rollForward(d: Date) {
+  const day = d.getDay();
+  if (day === 6) return addDays(d, 2);
+  if (day === 0) return addDays(d, 1);
+  return d;
+}
+
+function fmt(d: Date) {
+  return d.toISOString().slice(0, 10);
+}
+
+export type DateMath = {
+  received: string;
+  plus10: string;
+  extensionBase?: string;
+  determinationFinal: string;
+  extensionFinal?: string;
+};
+
+export function computeTimeline(
+  req: CPRARequest,
+  opts: { applyExtension: boolean; adjustWeekends: boolean }
+): { timeline: Timeline; math: DateMath } {
+  const { applyExtension, adjustWeekends } = opts;
+  if (!req || !req.receivedDate) throw new Error('Invalid request');
+  const received = toDate(req.receivedDate);
+  const plus10 = addDays(received, 10);
+  const determination = adjustWeekends ? rollForward(plus10) : plus10;
+  let extBase: Date | undefined;
+  let extFinal: Date | undefined;
+  if (applyExtension) {
+    extBase = addDays(plus10, 14);
+    extFinal = adjustWeekends ? rollForward(extBase) : extBase;
+  }
+  const roll = (d: Date) => (adjustWeekends ? rollForward(d) : d);
+  const prodBase = extFinal ?? determination;
+  const milestones = [
+    { label: 'Search kickoff', due: fmt(roll(addDays(received, 1))) },
+    { label: 'Privilege review', due: fmt(roll(addDays(prodBase, -3))) },
+    { label: 'Draft production', due: fmt(roll(addDays(prodBase, -1))) },
+  ];
+  const timeline: Timeline = {
+    determinationDue: fmt(determination),
+    extensionDue: extFinal ? fmt(extFinal) : undefined,
+    milestones,
+  };
+  const math: DateMath = {
+    received: fmt(received),
+    plus10: fmt(plus10),
+    extensionBase: extBase ? fmt(extBase) : undefined,
+    determinationFinal: fmt(determination),
+    extensionFinal: extFinal ? fmt(extFinal) : undefined,
+  };
+  return { timeline, math };
+}
+

--- a/frontend/src/steps/TimelineView.tsx
+++ b/frontend/src/steps/TimelineView.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Card from '../components/Card';
-import { postJSON } from '../lib/api';
 import type { CPRARequest, Timeline } from '../types';
+import { computeTimeline, DateMath } from '../lib/timeline';
 
 /** Display the computed timeline for approval. */
 export default function TimelineView({
@@ -11,37 +11,80 @@ export default function TimelineView({
   req: CPRARequest;
   registerNext: (fn: () => Timeline, ready?: boolean) => void;
 }) {
+  const [applyExt, setApplyExt] = useState(req.extension?.apply ?? false);
+  const [adjustWeekends, setAdjustWeekends] = useState(true);
   const [tl, setTl] = useState<Timeline | null>(null);
+  const [math, setMath] = useState<DateMath | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    (async () => {
-      try {
-        setTl(await postJSON('/api/timeline/calc', req));
-        setError(null);
-      } catch (e) {
-        console.error(e);
-        setError('Failed to calculate timeline');
-      }
-    })();
-  }, [req]);
+    try {
+      const { timeline, math } = computeTimeline(req, {
+        applyExtension: applyExt,
+        adjustWeekends,
+      });
+      setTl(timeline);
+      setMath(math);
+      setError(null);
+    } catch (e) {
+      console.error(e);
+      setError('Failed to calculate timeline');
+    }
+  }, [req, applyExt, adjustWeekends]);
 
   useEffect(() => {
     registerNext(() => tl!, !!tl);
   }, [tl, registerNext]);
 
   if (error) return <div className='text-red-600'>{error}</div>;
-  if (!tl) return <div>Calculating...</div>;
+  if (!tl || !math) return <div>Calculating...</div>;
 
   const draftProd = tl.milestones.find(m => m.label === 'Draft production')?.due ?? '';
 
   return (
     <div className='space-y-4'>
+      <div className='bg-yellow-50 border border-yellow-200 text-yellow-800 p-2 rounded'>
+        Holidays are not considered in this demo.
+      </div>
+      <div className='flex gap-4'>
+        <label className='flex items-center gap-2 text-sm'>
+          <input
+            type='checkbox'
+            checked={applyExt}
+            onChange={e => setApplyExt(e.target.checked)}
+          />
+          Apply extension
+        </label>
+        <label className='flex items-center gap-2 text-sm'>
+          <input
+            type='checkbox'
+            checked={adjustWeekends}
+            onChange={e => setAdjustWeekends(e.target.checked)}
+          />
+          Adjust for weekends
+        </label>
+      </div>
       <div className='grid grid-cols-3 gap-4'>
         <Card title='Determination Due' value={tl.determinationDue} />
         {tl.extensionDue && <Card title='Extension Due' value={tl.extensionDue} />}
         <Card title='Draft Production' value={draftProd} />
       </div>
+      <details className='border rounded p-2'>
+        <summary className='cursor-pointer'>Date math</summary>
+        <ul className='list-disc pl-5 text-sm space-y-1 mt-2'>
+          <li>Received: {math.received}</li>
+          <li>+10 days: {math.plus10}</li>
+          {applyExt && math.extensionBase && (
+            <li>+14 day extension: {math.extensionBase}</li>
+          )}
+          {adjustWeekends && (
+            <li>
+              Weekend adjustment: determination {tl.determinationDue}
+              {applyExt && tl.extensionDue ? `, extension ${tl.extensionDue}` : ''}
+            </li>
+          )}
+        </ul>
+      </details>
       {/* Primary action moved to Stepper */}
     </div>
   );


### PR DESCRIPTION
## Summary
- compute CPRA deadlines on the client instead of calling backend
- add toggles for extension and weekend adjustment plus accordion explaining date math
- show risk banner that holidays are not considered

## Testing
- `npm test -w frontend` *(fails: Missing script: "test")*
- `npm run build -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b20ae3f14c833280b682804cd91aca