### PR TITLE
feat: load letter templates locally with checklist and logging

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import ScopeForm from './steps/ScopeForm';
 import TimelineView from './steps/TimelineView';
 import LettersEditor from './steps/LettersEditor';
 import TasksAndChecklist from './steps/TasksAndChecklist';
-import type { CPRARequest, Timeline } from './types';
+import type { CPRARequest, Timeline, LetterKind } from './types';
 import { SAMPLE_NOTES } from './sampleNotes';
 
 /** Root application component orchestrating the workflow steps. */
@@ -63,6 +63,7 @@ export default function App() {
       const result = await nextRef.current();
       let action: 'accept' | 'edit' = 'accept';
       let editedSample = false;
+      let letterKind: LetterKind | undefined;
       switch (step) {
         case 0:
           setReq(result);
@@ -79,11 +80,14 @@ export default function App() {
           break;
         case 3:
           action = result.edited ? 'edit' : 'accept';
+          letterKind = result.kind;
           break;
       }
       const ms = Date.now() - startRef.current;
       if (step === 0) {
         console.log(`Notes step: ${ms}ms, editedSample=${editedSample}`);
+      } else if (step === 3) {
+        console.log(`Step ${steps[step]} (${letterKind}): ${action} in ${ms}ms`);
       } else {
         console.log(`Step ${steps[step]}: ${action} in ${ms}ms`);
       }

--- a/frontend/src/lib/templates.ts
+++ b/frontend/src/lib/templates.ts
@@ -1,0 +1,11 @@
+export const ACK_TEMPLATE = `
+<p>Dear Requester,</p>
+<p>This is to acknowledge receipt of your request on {{receivedDate}}.</p>
+<p>Sincerely,<br>City Clerk</p>
+`;
+
+export const EXT_TEMPLATE = `
+<p>Dear Requester,</p>
+<p>We require an extension to your request received on {{receivedDate}}.</p>
+<p>Sincerely,<br>City Clerk</p>
+`;

--- a/frontend/src/steps/LettersEditor.tsx
+++ b/frontend/src/steps/LettersEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { postJSON } from '../lib/api';
 import type { CPRARequest, Timeline, LetterKind } from '../types';
+import { ACK_TEMPLATE, EXT_TEMPLATE } from '../lib/templates';
 
 /** Step for previewing acknowledgment or extension letters. */
 export default function LettersEditor({
@@ -10,57 +10,130 @@ export default function LettersEditor({
 }: {
   req: CPRARequest;
   tl: Timeline;
-  registerNext: (fn: () => { edited: boolean }, ready?: boolean) => void;
+  registerNext: (fn: () => { edited: boolean; kind: LetterKind }, ready?: boolean) => void;
 }) {
   const [kind, setKind] = useState<LetterKind>('ack');
   const [html, setHtml] = useState('');
   const [initialHtml, setInitialHtml] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [toneFriendly, setToneFriendly] = useState(false);
+  const [includeSalutation, setIncludeSalutation] = useState(true);
+  const [includeContact, setIncludeContact] = useState(true);
 
-  useEffect(() => {
-    (async () => {
-      try {
-        const data = await postJSON(
-          `/api/letters/${kind === 'ack' ? 'ack' : 'extension'}`,
-          { request: req, timeline: tl, agency: { signatureBlock: 'City Clerk' } }
-        );
-        setHtml(data.html);
-        setInitialHtml(data.html);
-        setError(null);
-      } catch (e) {
-        console.error(e);
-        setError('Failed to load letter');
+  function stripHighlight(h: string) {
+    return h.replace(/<span class="merge-field"[^>]*>(.*?)<\/span>/g, '$1');
+  }
+
+  function highlight(h: string) {
+    return stripHighlight(h).replace(/{{[^}]+}}/g, m => `<span class="merge-field bg-yellow-100" title="From earlier steps">${m}</span>`);
+  }
+
+  function applyTone(h: string, friendly: boolean) {
+    if (kind === 'ack') {
+      const formal = 'This is to acknowledge receipt of your request on {{receivedDate}}.';
+      const friendlyTxt = "Thanks for your request on {{receivedDate}}. We'll get right on it.";
+      return friendly ? h.replace(formal, friendlyTxt) : h.replace(friendlyTxt, formal);
+    } else {
+      const formal = 'We require an extension to your request received on {{receivedDate}}.';
+      const friendlyTxt = "We're working on your request from {{receivedDate}} but need a bit more time.";
+      return friendly ? h.replace(formal, friendlyTxt) : h.replace(friendlyTxt, formal);
+    }
+  }
+
+  function toggleTone() {
+    const next = !toneFriendly;
+    setToneFriendly(next);
+    setHtml(h => highlight(applyTone(stripHighlight(h), next)));
+  }
+
+  function toggleSalutation() {
+    const next = !includeSalutation;
+    setIncludeSalutation(next);
+    setHtml(h => {
+      let raw = stripHighlight(h);
+      const salutation = '<p>Dear Requester,</p>';
+      if (next) {
+        if (!raw.includes(salutation)) raw = salutation + '\n' + raw;
+      } else {
+        raw = raw.replace(salutation + '\n', '').replace(salutation, '');
       }
-    })();
-  }, [kind, req, tl]);
+      return highlight(raw);
+    });
+  }
+
+  function toggleContact() {
+    const next = !includeContact;
+    setIncludeContact(next);
+    setHtml(h => {
+      let raw = stripHighlight(h);
+      const contact = '<p>Sincerely,<br>City Clerk</p>';
+      if (next) {
+        if (!raw.includes(contact)) raw = raw + '\n' + contact;
+      } else {
+        raw = raw.replace('\n' + contact, '').replace(contact, '');
+      }
+      return highlight(raw);
+    });
+  }
 
   useEffect(() => {
-    registerNext(() => ({ edited: html !== initialHtml }), html !== '');
-  }, [html, initialHtml, registerNext]);
+    try {
+      const base = kind === 'ack' ? ACK_TEMPLATE : EXT_TEMPLATE;
+      const h = highlight(base);
+      setHtml(h);
+      setInitialHtml(h);
+      setError(null);
+      setToneFriendly(false);
+      setIncludeSalutation(true);
+      setIncludeContact(true);
+    } catch (e) {
+      console.error(e);
+      setError('Failed to load letter');
+    }
+  }, [kind]);
+
+  useEffect(() => {
+    registerNext(() => ({ edited: html !== initialHtml, kind }), html !== '');
+  }, [html, initialHtml, registerNext, kind]);
 
   return (
-    <div className='space-y-3'>
-      <div className='flex gap-2'>
-        <button
-          className={'btn ' + (kind === 'ack' ? 'bg-blue-600 text-white' : '')}
-          onClick={() => setKind('ack')}
-        >
-          Acknowledgment
-        </button>
-        <button
-          className={'btn ' + (kind === 'extension' ? 'bg-blue-600 text-white' : '')}
-          onClick={() => setKind('extension')}
-        >
-          Extension
-        </button>
+    <div className='flex gap-4'>
+      <div className='w-48 space-y-2'>
+        <label className='flex items-center gap-2'>
+          <input type='checkbox' checked={toneFriendly} onChange={toggleTone} /> Friendly tone
+        </label>
+        <label className='flex items-center gap-2'>
+          <input type='checkbox' checked={includeSalutation} onChange={toggleSalutation} />
+          Include salutation
+        </label>
+        <label className='flex items-center gap-2'>
+          <input type='checkbox' checked={includeContact} onChange={toggleContact} /> Include contact block
+        </label>
       </div>
-      {error && <p className='text-red-600'>{error}</p>}
-      <textarea
-        className='w-full border p-3 h-64'
-        value={html}
-        onChange={e => setHtml(e.target.value)}
-      ></textarea>
-      {/* Primary action moved to Stepper */}
+      <div className='flex-1 space-y-3'>
+        <div className='flex gap-2'>
+          <button
+            className={'btn ' + (kind === 'ack' ? 'bg-blue-600 text-white' : '')}
+            onClick={() => setKind('ack')}
+          >
+            Acknowledgment
+          </button>
+          <button
+            className={'btn ' + (kind === 'extension' ? 'bg-blue-600 text-white' : '')}
+            onClick={() => setKind('extension')}
+          >
+            Extension
+          </button>
+        </div>
+        {error && <p className='text-red-600'>{error}</p>}
+        <textarea
+          className='w-full border p-3 h-64'
+          value={html}
+          onChange={e => setHtml(e.target.value)}
+        ></textarea>
+        <div className='border p-3' dangerouslySetInnerHTML={{ __html: html }} />
+        {/* Primary action moved to Stepper */}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add canned acknowledgment and extension templates with merge-field highlighting
- introduce left-rail checklist toggles for tone, salutation, and contact block
- log which template was accepted in step workflow

## Testing
- `npm run build -w frontend`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b20be94aa8833283aa262bf6e97c5f