### PR TITLE
Track edits and log step timings

### DIFF
--- a/frontend/src/steps/ScopeForm.tsx
+++ b/frontend/src/steps/ScopeForm.tsx
@@ -9,7 +9,7 @@ export default function ScopeForm({
   registerNext,
 }: {
   draft: CPRARequest;
-  registerNext: (fn: () => CPRARequest, ready?: boolean) => void;
+  registerNext: (fn: () => { data: CPRARequest; edited: boolean }, ready?: boolean) => void;
 }) {
   const [f, setF] = useState<CPRARequest>(draft);
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -64,8 +64,9 @@ export default function ScopeForm({
 
   useEffect(() => {
     const valid = Object.values(errors).every(e => !e);
-    registerNext(() => f, valid);
-  }, [f, errors, registerNext]);
+    const edited = JSON.stringify(f) !== JSON.stringify(draft);
+    registerNext(() => ({ data: f, edited }), valid);
+  }, [f, errors, registerNext, draft]);
 
   const confirmedCount = [
     f.requester.name,


### PR DESCRIPTION
## Summary
- Record start/end timestamps for each workflow step and log them when leaving a step
- Detect and log whether user edits extracted data in scope, timeline, and letter steps
- Report abandon points when user navigates away or resets before completing workflow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build -w frontend`

------
https://chatgpt.com/codex/tasks/task_e_68b20ec5a3708332bd0fc43016044856