### PR TITLE
Improve note extraction via backend API

### DIFF
--- a/backend/express/src/services/extractor.ts
+++ b/backend/express/src/services/extractor.ts
@@ -12,18 +12,21 @@ function firstEmail(text: string): string | null {
 /** Return the first date-like string found in `text` or `null`. */
 function firstDate(text: string): string | null {
   const m = text.match(DATE_RE);
-  return m ? m[0] : null;
+  if (!m) return null;
+  const raw = m[0];
+  const d = new Date(raw);
+  return isNaN(d.getTime()) ? raw : d.toISOString().slice(0, 10);
 }
 
 /** Derive a draft CPRA request from free-form meeting notes. */
 export function extractScope(notes: string): CPRARequestDraft {
   const email = firstEmail(notes) || 'requester@example.com';
   let name = 'Unknown Requester';
-  const nameMatch = notes.match(/(?:from|by|request(?:or|ed) by)[:\s]+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)/i);
+  const nameMatch = notes.match(/(?:from|by|request(?:or|ed) by|requester)[:\s]+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)/i);
   if (nameMatch) name = nameMatch[1];
   const received = firstDate(notes) || '2025-01-01';
   let desc = 'All emails related to agenda item';
-  const descMatch = notes.match(/(?:request|records sought)[:\s]+(.+)/i);
+  const descMatch = notes.match(/(?:request|records sought|subject)[:\s]+(.+)/i);
   if (descMatch) desc = descMatch[1].trim();
   const requester: Requester = { name, email };
   const draft: CPRARequest = {

--- a/backend/express/tests/extractor.test.ts
+++ b/backend/express/tests/extractor.test.ts
@@ -16,3 +16,16 @@ test('extractScope parses notes', () => {
   assert.equal(draft.request.receivedDate, '2025-01-05');
   assert.equal(draft.request.description, 'Budget documents.');
 });
+
+test('extractScope handles Requester label and natural date', () => {
+  const notes =
+    'Requester: Karen Nuisance (email: knuisa@gmail.com)\nDate/Time Received: August 29, 2025, 11:14 a.m. PT\nSubject: California Public Records Act request related to Agenda Item 5 (Vista Ridge Transfer Station modernization).';
+  const draft = extractScope(notes);
+  assert.equal(draft.request.requester.email, 'knuisa@gmail.com');
+  assert.equal(draft.request.requester.name, 'Karen Nuisance');
+  assert.equal(draft.request.receivedDate, '2025-08-29');
+  assert.equal(
+    draft.request.description,
+    'California Public Records Act request related to Agenda Item 5 (Vista Ridge Transfer Station modernization).'
+  );
+});

--- a/backend/fastapi/app/services/extractor.py
+++ b/backend/fastapi/app/services/extractor.py
@@ -3,7 +3,10 @@ import re
 from ..models import CPRARequestDraft, CPRARequest, Requester, DateRange, Extension
 
 EMAIL_RE = re.compile(r'[\w\.-]+@[\w\.-]+')
-DATE_RE = re.compile(r'(\b\d{4}-\d{2}-\d{2}\b|\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+\d{4}\b)', re.I)
+DATE_RE = re.compile(
+    r'(\b\d{4}-\d{2}-\d{2}\b|\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+\d{4}\b)',
+    re.I,
+)
 
 def _first_email(text):
     """Return the first email address found in ``text`` or ``None``."""
@@ -13,18 +16,30 @@ def _first_email(text):
 def _first_date(text):
     """Return the first date-like string found in ``text`` or ``None``."""
     m = DATE_RE.search(text)
-    return m.group(0) if m else None
+    if not m:
+        return None
+    raw = m.group(0)
+    from dateutil import parser
+
+    try:
+        return parser.parse(raw).date().isoformat()
+    except Exception:  # pragma: no cover - fallback for unparsable dates
+        return raw
 
 def extract_scope(notes: str) -> CPRARequestDraft:
     """Derive a draft CPRA request from free-form meeting notes."""
     email = _first_email(notes) or "requester@example.com"
     name = "Unknown Requester"
-    m = re.search(r'(?:from|by|request(?:or|ed) by)[:\s]+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)', notes, re.I)
+    m = re.search(
+        r'(?:from|by|request(?:or|ed) by|requester)[:\s]+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)',
+        notes,
+        re.I,
+    )
     if m:
         name = m.group(1)
     received = _first_date(notes) or "2025-01-01"
     desc = "All emails related to agenda item"
-    md = re.search(r'(?:request|records sought)[:\s]+(.+)', notes, re.I)
+    md = re.search(r'(?:request|records sought|subject)[:\s]+(.+)', notes, re.I)
     if md:
         desc = md.group(1).strip()
     draft = CPRARequest(

--- a/backend/fastapi/tests/test_extractor.py
+++ b/backend/fastapi/tests/test_extractor.py
@@ -14,3 +14,19 @@ def test_extract_scope_parses_notes():
     assert draft.request.requester.name == "John Doe"
     assert draft.request.receivedDate == "2025-01-05"
     assert draft.request.description == "Budget documents."
+
+
+def test_extract_scope_handles_requester_and_natural_date():
+    notes = (
+        "Requester: Karen Nuisance (email: knuisa@gmail.com)\n"
+        "Date/Time Received: August 29, 2025, 11:14 a.m. PT\n"
+        "Subject: California Public Records Act request related to Agenda Item 5 (Vista Ridge Transfer Station modernization)."
+    )
+    draft = extract_scope(notes)
+    assert draft.request.requester.email == "knuisa@gmail.com"
+    assert draft.request.requester.name == "Karen Nuisance"
+    assert draft.request.receivedDate == "2025-08-29"
+    assert (
+        draft.request.description
+        == "California Public Records Act request related to Agenda Item 5 (Vista Ridge Transfer Station modernization)."
+    )


### PR DESCRIPTION
## Summary
- use backend scope extractor instead of frontend regex stub
- support `Requester:` label, natural-language dates, and subject-based descriptions
- add tests for new extraction paths

## Testing
- `node --import tsx --test backend/express/tests/extractor.test.ts`
- `pytest backend/fastapi/tests/test_extractor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b226e0529c83329ff727189e6e1c33