### PR TITLE
Fix matter extraction and improve step flow

### DIFF
--- a/backend/express/src/services/extractor.ts
+++ b/backend/express/src/services/extractor.ts
@@ -18,7 +18,10 @@ export function extractScope(notes: string): CPRARequestDraft {
   const dm = notes.match(/Date Received:\s*([^\n]+)/);
   if (dm) received = parseDate(dm[1]);
   let matter = 'No matter found';
-  const sm = notes.match(/Matter:\s*([^\n]+)/);
+  // Capture text after "Matter:" on the same line, allowing for CRLF line endings and
+  // variations in casing. This previously failed when the notes used Windows style
+  // newlines or contained extra spaces, which left the matter field unset.
+  const sm = notes.match(/Matter\s*:\s*([^\r\n]+)/i);
   if (sm) matter = sm[1].trim();
   let rangeStart: string | undefined;
   let rangeEnd: string | undefined = received;

--- a/backend/express/tests/extractor.test.ts
+++ b/backend/express/tests/extractor.test.ts
@@ -22,3 +22,10 @@ test('extractScope parses summary', () => {
   assert.equal(draft.request.range?.end, '2025-01-05');
 });
 
+test('extractScope handles CRLF line endings', () => {
+  const notes =
+    'CPRA Request Summary (for tracker)\r\n\r\nRequester: Jane Roe – jane.roe@example.com\r\n\r\nDate Received: Jan 5, 2025\r\n\r\nMatter: Budget Inquiry\r\n\r\nRecord Types: Emails\r\n';
+  const draft = extractScope(notes);
+  assert.equal(draft.request.matter, 'Budget Inquiry');
+});
+

--- a/backend/fastapi/app/services/extractor.py
+++ b/backend/fastapi/app/services/extractor.py
@@ -24,7 +24,10 @@ def extract_scope(notes: str) -> CPRARequestDraft:
     if m:
         received = _parse_date(m.group(1))
     matter = "No matter found"
-    m = re.search(r"Matter:\s*([^\n]+)", notes)
+    # Capture text following "Matter:" regardless of line ending style or case.
+    # Previously the regex only handled Unix newlines which caused the matter
+    # field to be missed when Windows CRLF endings were present.
+    m = re.search(r"Matter\s*:\s*([^\r\n]+)", notes, flags=re.IGNORECASE)
     if m:
         matter = m.group(1).strip()
     range_start = None

--- a/backend/fastapi/tests/test_extractor.py
+++ b/backend/fastapi/tests/test_extractor.py
@@ -26,3 +26,16 @@ def test_extract_scope_parses_summary():
     assert draft.request.preferredFormatDelivery == "Email"
     assert draft.request.range.start == "2024-01-01"
     assert draft.request.range.end == "2025-01-05"
+
+
+def test_extract_scope_handles_crlf():
+    """Matter line should parse with CRLF endings."""
+    notes = (
+        "CPRA Request Summary (for tracker)\r\n\r\n"
+        "Requester: Jane Roe – jane.roe@example.com\r\n\r\n"
+        "Date Received: Jan 5, 2025\r\n\r\n"
+        "Matter: Budget Inquiry\r\n\r\n"
+        "Record Types: Emails\r\n"
+    )
+    draft = extract_scope(notes)
+    assert draft.request.matter == "Budget Inquiry"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,6 +68,7 @@ export default function App() {
       let letterKind: LetterKind | undefined;
       switch (step) {
         case 0:
+          if (!result) throw new Error('Extraction returned no data');
           setReq(result);
           editedSample = notes !== SAMPLE_NOTES;
           action = editedSample ? 'edit' : 'accept';
@@ -153,6 +154,9 @@ export default function App() {
           )}
           {step === 1 && req && (
             <ScopeForm draft={req} notes={notes} registerNext={registerNext} />
+          )}
+          {step === 1 && !req && (
+            <div className='text-red-600'>Missing request data. Please go back and retry extraction.</div>
           )}
           {step === 2 && req && <TimelineView req={req} registerNext={registerNext} />}
           {step === 3 && req && tl && (

--- a/frontend/src/steps/NotesUpload.tsx
+++ b/frontend/src/steps/NotesUpload.tsx
@@ -18,18 +18,17 @@ export default function NotesUpload({
     requester: string | null;
     matter: string | null;
     received: string | null;
-    description: string | null;
     recordTypes: string[];
     custodians: string[];
     preferred: string | null;
-    conf: { requester: number; matter: number; received: number; description: number };
+    conf: { requester: number; matter: number; received: number };
   };
 
   const [preview, setPreview] = useState<Preview | null>(null);
 
   type ExtractResp = {
     request: CPRARequest;
-    confidences: { requester: number; matter: number; receivedDate: number; description: number };
+    confidences: { requester: number; matter: number; receivedDate: number };
   };
 
   async function runExtraction(text: string): Promise<ExtractResp> {
@@ -51,7 +50,6 @@ export default function NotesUpload({
             requester: data.request.requester.name || null,
             matter: data.request.matter || null,
             received: data.request.receivedDate || null,
-            description: data.request.description || null,
             recordTypes: data.request.recordTypes || [],
             custodians: data.request.custodians || [],
             preferred: data.request.preferredFormatDelivery || null,
@@ -59,7 +57,6 @@ export default function NotesUpload({
               requester: data.confidences.requester,
               matter: data.confidences.matter,
               received: data.confidences.receivedDate,
-              description: data.confidences.description,
             },
           });
         })
@@ -67,8 +64,11 @@ export default function NotesUpload({
     } else {
       setPreview(null);
     }
-    registerNext(extract, notes.trim().length > 0);
-  }, [notes, registerNext]);
+  }, [notes]);
+
+  useEffect(() => {
+    registerNext(extract, !!preview);
+  }, [registerNext, preview]);
 
   /** Extraction returning a CPRARequest object. */
   async function extract() {
@@ -139,11 +139,6 @@ export default function NotesUpload({
             <span className='font-medium'>Logged:</span>{' '}
             {preview.received || <span className='text-gray-400'>N/A</span>}
             <ConfidenceChip score={preview.conf.received} />
-          </p>
-          <p>
-            <span className='font-medium'>Description:</span>{' '}
-            {preview.description || <span className='text-gray-400'>N/A</span>}
-            <ConfidenceChip score={preview.conf.description} />
           </p>
           {preview.recordTypes.length > 0 && (
             <p>


### PR DESCRIPTION
## Summary
- handle CRLF and case variations when parsing Matter lines
- hide Description preview and wait for extraction before enabling Step 2
- guard against missing request data to avoid blank Step 2
- add regression tests for Matter parsing with CRLF endings

## Testing
- `npx tsx --test backend/express/tests/extractor.test.ts`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b245e95a0c83328f20e292f718c17b