### PR TITLE
Normalize date handling and streamline records display

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -153,7 +153,7 @@ export default function App() {
             <NotesUpload notes={notes} setNotes={setNotes} registerNext={registerNext} />
           )}
           {step === 1 && req && (
-            <ScopeForm draft={req} notes={notes} registerNext={registerNext} />
+            <ScopeForm draft={req} registerNext={registerNext} />
           )}
           {step === 1 && !req && (
             <div className='text-red-600'>Missing request data. Please go back and retry extraction.</div>

--- a/frontend/src/steps/ScopeForm.tsx
+++ b/frontend/src/steps/ScopeForm.tsx
@@ -6,11 +6,9 @@ import type { CPRARequest } from '../types';
  */
 export default function ScopeForm({
   draft,
-  notes,
   registerNext,
 }: {
   draft: CPRARequest;
-  notes: string;
   registerNext: (fn: () => { data: CPRARequest; edited: boolean }, ready?: boolean) => void;
 }) {
   const [f, setF] = useState<CPRARequest>(draft);
@@ -158,32 +156,10 @@ export default function ScopeForm({
             </label>
             <textarea
               className='w-full border p-2'
-              rows={4}
+              rows={6}
               value={f.description}
               onChange={e => handle('description', e.target.value)}
             />
-            <div className='mt-2 text-sm space-y-1'>
-              {f.recordTypes.length > 0 && (
-                <p>
-                  <span className='font-medium'>Record Types:</span> {f.recordTypes.join(', ')}
-                </p>
-              )}
-              {f.custodians.length > 0 && (
-                <p>
-                  <span className='font-medium'>Custodians:</span> {f.custodians.join(', ')}
-                </p>
-              )}
-              {f.preferredFormatDelivery && (
-                <p>
-                  <span className='font-medium'>Preferred Format/Delivery:</span> {f.preferredFormatDelivery}
-                </p>
-              )}
-              <textarea
-                className='w-full h-40 border p-2 mt-1'
-                value={notes}
-                readOnly
-              />
-            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Normalize extracted received date to `YYYY-MM-DD` and compose a single records description
- Show records information inside the "Records Sought" field and drop redundant notes block
- Populate acknowledgment/extension letters with the logged date instead of a placeholder

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2905ab7e08332ac6e170c44435e0a